### PR TITLE
Event re-execute class steps!

### DIFF
--- a/app/Controller/Tests/Five.php
+++ b/app/Controller/Tests/Five.php
@@ -1,0 +1,23 @@
+<?php
+namespace Corley\Demo\Controller\Tests;
+
+use Corley\Middleware\Annotations\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Corley\Middleware\Annotations\After;
+use Corley\Middleware\Annotations\Before;
+use Zend\EventManager\EventManager;
+
+class Five
+{
+    /**
+     * @Route("/flow")
+     * @Before(targetClass="Corley\Demo\Controller\Tests\One", targetMethod="action")
+     * @After(targetClass="Corley\Demo\Controller\Tests\Three", targetMethod="action")
+     */
+    public function action()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+}
+

--- a/app/Controller/Tests/Four.php
+++ b/app/Controller/Tests/Four.php
@@ -1,0 +1,18 @@
+<?php
+namespace Corley\Demo\Controller\Tests;
+
+use Corley\Middleware\Annotations\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Corley\Middleware\Annotations\After;
+use Zend\EventManager\EventManager;
+
+class Four
+{
+    public function methodB()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+}
+
+

--- a/app/Controller/Tests/One.php
+++ b/app/Controller/Tests/One.php
@@ -1,0 +1,29 @@
+<?php
+namespace Corley\Demo\Controller\Tests;
+
+use Corley\Middleware\Annotations\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Corley\Middleware\Annotations\After;
+use Corley\Middleware\Annotations\Before;
+use Zend\EventManager\EventManager;
+
+/**
+ * @Before(targetClass="Corley\Demo\Controller\Tests\Two", targetMethod="methodB")
+ */
+class One
+{
+    /**
+     * @Route("/base-flow")
+     * @Before(targetClass="Corley\Demo\Controller\Tests\One", targetMethod="methodC")
+     */
+    public function action()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+
+    public function methodC()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+}

--- a/app/Controller/Tests/Three.php
+++ b/app/Controller/Tests/Three.php
@@ -1,0 +1,29 @@
+<?php
+namespace Corley\Demo\Controller\Tests;
+
+use Corley\Middleware\Annotations\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Corley\Middleware\Annotations\After;
+use Zend\EventManager\EventManager;
+
+/**
+ * @After(targetClass="Corley\Demo\Controller\Tests\Four", targetMethod="methodB")
+ */
+class Three
+{
+    /**
+     * @Route("/after-flow")
+     * @After(targetClass="Corley\Demo\Controller\Tests\Three", targetMethod="methodC")
+     */
+    public function action()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+
+    public function methodC()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+}
+

--- a/app/Controller/Tests/Two.php
+++ b/app/Controller/Tests/Two.php
@@ -1,0 +1,18 @@
+<?php
+namespace Corley\Demo\Controller\Tests;
+
+use Corley\Middleware\Annotations\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Corley\Middleware\Annotations\After;
+use Corley\Middleware\Annotations\Before;
+use Zend\EventManager\EventManager;
+
+class Two
+{
+    public function methodB()
+    {
+        echo __CLASS__ . "::" . __FUNCTION__ . PHP_EOL;
+    }
+}
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ like: authentication, serializers etc? Simple, defining steps:
     class IndexController
     {
         /**
-         * @Before(targetClass="MyClass", targetMethod="myMethod")
+         * @Before(targetClass="MyClass", targetMethod="aMethod")
          * @Route("/", methods={"GET"})
          */
         public function indexAction(Request $request, Response $response) { /** code */ }

--- a/src/Executor/AnnotExecutor.php
+++ b/src/Executor/AnnotExecutor.php
@@ -14,11 +14,13 @@ class AnnotExecutor
     private $reader;
     private $request;
     private $response;
+    private $limiter;
 
     public function __construct(ContainerInterface $container, HookReader $reader)
     {
         $this->container = $container;
         $this->reader = $reader;
+        $this->limiter = [];
     }
 
     public function execute(Request $request, Response $response, array $matched)
@@ -29,30 +31,43 @@ class AnnotExecutor
         $action     = $matched["action"];
         $controller = $matched["controller"];
 
-        $this->executeActionsFor($controller, $action, Before::class, $matched);
+        $this->limiter = [];
+        $this->executeActionsFor($controller, $action, Before::class, $matched, false);
+
         $controller = $this->getContainer()->get($controller);
         $data = array_diff_key($matched, array_flip(["annotation", "_route", "controller", "action"]));
         $actionReturn = call_user_func_array([$controller, $action], array_merge([$request, $response], $data));
-        $this->executeActionsFor($controller, $action, After::class, $actionReturn);
+
+        $this->limiter = [];
+        $this->executeActionsFor($controller, $action, After::class, $actionReturn, true);
     }
 
-    private function executeActionsFor($controller, $action, $filterClass, $data = null)
+    private function executeActionsFor($controller, $action, $filterClass, $data = null, $after = false)
     {
         $methodAnnotations = $this->getReader()->getMethodAnnotationsFor($controller, $action, $filterClass);
-        $this->executeSteps($methodAnnotations, [$this, __FUNCTION__], $filterClass, $data);
+        $this->executeSteps($methodAnnotations, [$this, __FUNCTION__], $filterClass, $data, $after);
 
         $classAnnotations = $this->getReader()->getClassAnnotationsFor($controller, $filterClass);
-        $this->executeSteps($classAnnotations, [$this, __FUNCTION__], $filterClass, $data);
+        $this->executeSteps($classAnnotations, [$this, __FUNCTION__], $filterClass, $data, $after);
     }
 
-    private function executeSteps(array $annotations, callable $method, $filterClass, $data = null)
+    private function executeSteps(array $annotations, callable $method, $filterClass, $data = null, $after = false)
     {
         foreach ($annotations as $annotation) {
-            $method($annotation->targetClass, $annotation->targetMethod, $filterClass, $data);
-            $newController = $this->getContainer()->get($annotation->targetClass);
-            call_user_func_array([$newController, $annotation->targetMethod], [
-                $this->request, $this->response, $data
-            ]);
+            $limiterKey = $annotation->targetClass . "::" . $annotation->targetMethod;
+            if (!array_key_exists($limiterKey, $this->limiter)) {
+                if (!$after) {
+                    $method($annotation->targetClass, $annotation->targetMethod, $filterClass, $data, $after);
+                }
+                $newController = $this->getContainer()->get($annotation->targetClass);
+                call_user_func_array([$newController, $annotation->targetMethod], [
+                    $this->request, $this->response, $data
+                ]);
+                if ($after) {
+                    $method($annotation->targetClass, $annotation->targetMethod, $filterClass, $data, $after);
+                }
+                $this->limiter[$limiterKey][] = true;
+            }
         }
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -106,4 +106,65 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString('{"one": 325, "two": 327}', $response->getContent());
     }
+
+    public function testEventsFlow()
+    {
+        $request = Request::create("/base-flow");
+        $response = new Response();
+
+        ob_start();
+        $this->app->run($request, $response);
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals(<<<EOF
+Corley\\Demo\\Controller\\Tests\\Two::methodB
+Corley\\Demo\\Controller\\Tests\\One::methodC
+Corley\\Demo\\Controller\\Tests\\One::action
+
+EOF
+        ,$content);
+    }
+
+    public function testAfterEventsFlow()
+    {
+        $request = Request::create("/after-flow");
+        $response = new Response();
+
+        ob_start();
+        $this->app->run($request, $response);
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals(<<<EOF
+Corley\\Demo\\Controller\\Tests\\Three::action
+Corley\\Demo\\Controller\\Tests\\Three::methodC
+Corley\\Demo\\Controller\\Tests\\Four::methodB
+
+EOF
+        ,$content);
+    }
+
+    public function testCicleEventsFlow()
+    {
+        $request = Request::create("/flow");
+        $response = new Response();
+
+        ob_start();
+        $this->app->run($request, $response);
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals(<<<EOF
+Corley\\Demo\\Controller\\Tests\\Two::methodB
+Corley\\Demo\\Controller\\Tests\\One::methodC
+Corley\\Demo\\Controller\\Tests\\One::action
+Corley\\Demo\\Controller\\Tests\\Five::action
+Corley\\Demo\\Controller\\Tests\\Three::action
+Corley\\Demo\\Controller\\Tests\\Three::methodC
+Corley\\Demo\\Controller\\Tests\\Four::methodB
+
+EOF
+        ,$content);
+    }
 }


### PR DESCRIPTION
See that effectively the execution for the before step is:

```
Corley\\Demo\\Controller\\Tests\\Two::methodB
Corley\\Demo\\Controller\\Tests\\One::methodC
Corley\\Demo\\Controller\\Tests\\Two::methodB
Corley\\Demo\\Controller\\Tests\\One::action
```

Be want:

```
Corley\\Demo\\Controller\\Tests\\Two::methodB
Corley\\Demo\\Controller\\Tests\\One::methodC
Corley\\Demo\\Controller\\Tests\\One::action
```
Just because `One::methodC` have also the `Two::methodB` before step as the `One::action` (same base class)

Also a circular recursion actually is not avoidable

Related to #7 